### PR TITLE
Add client details to order and ticket email template variables

### DIFF
--- a/src/bb-modules/Order/Service.php
+++ b/src/bb-modules/Order/Service.php
@@ -347,6 +347,9 @@ class Service implements InjectionAwareInterface
         $data['title']          = $model->title;
         $data['meta']           = $this->di['db']->getAssoc('SELECT name, value FROM client_order_meta WHERE client_order_id = :id', array(':id' => $model->id));
         $data['active_tickets'] = $supportService->getActiveTicketsCountForOrder($model);
+        
+        $client = $this->di['db']->getExistingModelById('Client', $model->client_id, 'Client not found');
+        $data['client'] = $clientService->toApiArray($client, false);
 
         if ($identity instanceof \Model_Admin) {
             $data['config'] = $this->getConfig($model);
@@ -356,8 +359,6 @@ class Service implements InjectionAwareInterface
             }else{
                 $data['plugin'] = null;
             }
-            $client = $this->di['db']->getExistingModelById('Client', $model->client_id, 'Client not found');
-            $data['client'] = $clientService->toApiArray($client, false);
         }
 
         return $data;

--- a/src/bb-modules/Support/Service.php
+++ b/src/bb-modules/Support/Service.php
@@ -548,6 +548,7 @@ class Service implements \Box\InjectionAwareInterface
         $data['replies']  = $this->messageGetRepliesCount($model);
         $data['first']    = $this->messageToApiArray($firstSupportTicketMessage);
         $data['helpdesk'] = $this->helpdeskToApiArray($supportHelpdesk);
+        $data['client']     = $this->getClientApiArrayForTicket($model);
 
         if ($deep) {
             $messages = $this->messageGetTicketMessages($model);
@@ -559,7 +560,6 @@ class Service implements \Box\InjectionAwareInterface
         if ($identity instanceof \Model_Admin) {
             $data['rel']        = $this->_getRelDetails($model);
             $data['priority']   = $model->priority;
-            $data['client']     = $this->getClientApiArrayForTicket($model);
             $supportTicketNotes = $this->di['db']->find('SupportTicketNote', 'support_ticket_id = :support_ticket_id', array(':support_ticket_id' => $model->id));
 
             foreach ($supportTicketNotes as $note) {


### PR DESCRIPTION
Fixed issue where when there is a new order or ticket, email templates don't receive client's details in the template variables.