### PR TITLE
Product list from  catagory_get_list is not sorted by priority

### DIFF
--- a/src/bb-modules/Product/Service.php
+++ b/src/bb-modules/Product/Service.php
@@ -718,7 +718,10 @@ class Service implements InjectionAwareInterface
                 $min_price = $startingPrice;
             }
         }
-
+        // sort products by priority
+        $keys = array_column($products, 'priority');
+        array_multisort($keys, SORT_ASC, $products);
+        
         $data                        = $this->di['db']->toArray($model);
         $data['price_starting_from'] = $min_price;
         $data['icon_url']            = $model->icon_url;


### PR DESCRIPTION
Some themes uses the product list  from the catagory_get_list array.
but that list  isn't sorted by product priority

This will fix annoying bug.
